### PR TITLE
Claude Code用のプロジェクト設定を追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ composer.lock
 .phpunit.result.cache
 .phpunit.cache/
 .php-cs-fixer.cache
+.serena

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,51 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## コマンド
+
+### テスト実行
+```bash
+# 全てのテスト（CS-Fixer, PHPStan, PHPUnit）を実行
+composer tests
+
+# PHPUnitのみ実行
+./vendor/bin/phpunit
+
+# 特定のテストファイルを実行
+./vendor/bin/phpunit tests/Client/ClientTest.php
+
+# 特定のテストメソッドを実行
+./vendor/bin/phpunit --filter testRequestSuccess
+```
+
+### コード品質チェック
+```bash
+# PHPStanで静的解析（レベル9）
+./vendor/bin/phpstan analyse
+
+# PHP CS-Fixerでコードスタイルチェック（ドライラン）
+./vendor/bin/php-cs-fixer fix --dry-run
+
+# コードスタイル自動修正
+composer cs-fix
+# または
+./vendor/bin/php-cs-fixer fix
+```
+
+## アーキテクチャ
+
+### コアコンポーネント
+- **`Printgraph`**: メインのエントリーポイント。API操作のファサードとして機能
+- **`Client\Client`**: GuzzleHttpをラップし、Result型（Ok/Err）でレスポンスを返すHTTPクライアント
+- **`Api\Pdf\Generator`**: PDF生成APIのエンドポイント実装
+
+### 依存関係
+- **prewk/result**: Result型（Ok/Err）によるエラーハンドリング
+- **guzzlehttp/guzzle**: HTTPクライアント
+
+### コーディング規約
+- PHP 8.1以上の機能を活用（readonly, constructor property promotion）
+- 全ファイルで `declare(strict_types=1)` を使用
+- PHP CS-Fixerルール: `@PER-CS`, `@PHP82Migration`
+- PHPStanレベル9での厳格な型チェック


### PR DESCRIPTION
## 概要
Claude Codeでの開発をスムーズにするための設定ファイルを追加しました。

## 変更内容
- `.gitignore`に`.serena`ディレクトリを追加
- `CLAUDE.md`ファイルを新規作成

## CLAUDE.mdの内容
- **コマンドリファレンス**: テスト実行とコード品質チェックのコマンド一覧
- **アーキテクチャ説明**: Printgraph SDK の主要コンポーネント構成
- **コーディング規約**: PHP 8.1+、strict_types、CS-Fixer、PHPStan の設定

## テスト
- [x] .gitignoreが正しく動作することを確認
- [x] CLAUDE.mdの内容がプロジェクトの実態と一致していることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)