### PR TITLE
feat: Result型の型安全性を向上

### DIFF
--- a/src/Api/Pdf/Generator/GeneratorInterface.php
+++ b/src/Api/Pdf/Generator/GeneratorInterface.php
@@ -10,8 +10,11 @@ use Psr\Http\Message\ResponseInterface;
 interface GeneratorInterface
 {
     /**
+     * PDF生成リクエストを実行
+     *
      * @param GenerateRequest $generateRequest
-     * @return Result<ResponseInterface, ResponseInterface>
+     * @return Result<\Printgraph\PhpSdk\Client\Response\SuccessResponse, \Printgraph\PhpSdk\Client\Response\ErrorResponse>
+     * @phpstan-return Result<\Printgraph\PhpSdk\Client\Response\SuccessResponse, \Printgraph\PhpSdk\Client\Response\ErrorResponse>
      *
      * @throws \Exception
      */

--- a/src/Client/Client.php
+++ b/src/Client/Client.php
@@ -16,15 +16,19 @@ final class Client implements ClientInterface
     ) {}
 
     /**
+     * HTTPリクエストを実行し、型安全なResult型で結果を返す
+     *
      * @throws GuzzleException
+     * @return Result<Response\SuccessResponse, Response\ErrorResponse>
+     * @phpstan-return Result<Response\SuccessResponse, Response\ErrorResponse>
      */
     public function request(string $method, string $path, array $options = []): Result
     {
         $response = $this->httpClient->request($method, $path, $options);
         if ($response->getStatusCode() >= 400) {
-            return new Err($response);
+            return new Err(new Response\ErrorResponse($response));
         }
 
-        return new Ok($response);
+        return new Ok(new Response\SuccessResponse($response));
     }
 }

--- a/src/Client/ClientInterface.php
+++ b/src/Client/ClientInterface.php
@@ -10,8 +10,14 @@ use Psr\Http\Message\ResponseInterface;
 interface ClientInterface
 {
     /**
-     * @param mixed[] $options
-     * @return Result<ResponseInterface, ResponseInterface>
+     * HTTPリクエストを実行し、型安全なResult型で結果を返す
+     *
+     * @param string $method HTTPメソッド
+     * @param string $path リクエストパス
+     * @param mixed[] $options Guzzleオプション
+     * @return Result<Response\SuccessResponse, Response\ErrorResponse>
+     *
+     * @phpstan-return Result<Response\SuccessResponse, Response\ErrorResponse>
      */
     public function request(string $method, string $path, array $options = []): Result;
 }

--- a/src/Client/Response/ErrorResponse.php
+++ b/src/Client/Response/ErrorResponse.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Printgraph\PhpSdk\Client\Response;
+
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * エラーレスポンスを表す値オブジェクト
+ *
+ * @phpstan-immutable
+ */
+final class ErrorResponse
+{
+    public function __construct(
+        private readonly ResponseInterface $response,
+    ) {}
+
+    public function getResponse(): ResponseInterface
+    {
+        return $this->response;
+    }
+
+    public function getStatusCode(): int
+    {
+        return $this->response->getStatusCode();
+    }
+
+    public function getErrorMessage(): string
+    {
+        return $this->response->getBody()->getContents();
+    }
+
+    public function isClientError(): bool
+    {
+        $code = $this->getStatusCode();
+        return $code >= 400 && $code < 500;
+    }
+
+    public function isServerError(): bool
+    {
+        $code = $this->getStatusCode();
+        return $code >= 500 && $code < 600;
+    }
+
+    /**
+     * @return array<string, string[]>
+     */
+    public function getHeaders(): array
+    {
+        return $this->response->getHeaders();
+    }
+}

--- a/src/Client/Response/SuccessResponse.php
+++ b/src/Client/Response/SuccessResponse.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Printgraph\PhpSdk\Client\Response;
+
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * 成功レスポンスを表す値オブジェクト
+ *
+ * @phpstan-immutable
+ */
+final class SuccessResponse
+{
+    public function __construct(
+        private readonly ResponseInterface $response,
+    ) {}
+
+    public function getResponse(): ResponseInterface
+    {
+        return $this->response;
+    }
+
+    public function getStatusCode(): int
+    {
+        return $this->response->getStatusCode();
+    }
+
+    public function getBody(): string
+    {
+        return $this->response->getBody()->getContents();
+    }
+
+    /**
+     * @return array<string, string[]>
+     */
+    public function getHeaders(): array
+    {
+        return $this->response->getHeaders();
+    }
+}

--- a/tests/Api/Pdf/Generator/GeneratorTest.php
+++ b/tests/Api/Pdf/Generator/GeneratorTest.php
@@ -29,7 +29,7 @@ final class GeneratorTest extends TestCase
                     'Accept' => ['application/pdf', 'application/json'],
                 ],
             ])
-            ->willReturn(new Ok(new Response(200, [], 'pdf-content')))
+            ->willReturn(new Ok(new \Printgraph\PhpSdk\Client\Response\SuccessResponse(new Response(200, [], 'pdf-content'))))
         ;
 
         $generator = new Generator($mockClient);
@@ -40,9 +40,10 @@ final class GeneratorTest extends TestCase
 
         self::assertInstanceOf(Ok::class, $result);
 
-        /** @var ResponseInterface $response */
+        /** @var \Printgraph\PhpSdk\Client\Response\SuccessResponse $response */
         $response = $result->unwrap();
-        self::assertEquals('pdf-content', $response->getBody()->getContents());
+        self::assertInstanceOf(\Printgraph\PhpSdk\Client\Response\SuccessResponse::class, $response);
+        self::assertEquals('pdf-content', $response->getBody());
     }
 
     public function testGeneratorRequestFailure(): void
@@ -60,7 +61,7 @@ final class GeneratorTest extends TestCase
                     'Accept' => ['application/pdf', 'application/json'],
                 ],
             ])
-            ->willReturn(new Err(new Response(500, [], 'error')))
+            ->willReturn(new Err(new \Printgraph\PhpSdk\Client\Response\ErrorResponse(new Response(500, [], 'error'))))
         ;
 
         $generator = new Generator($mockClient);
@@ -70,5 +71,12 @@ final class GeneratorTest extends TestCase
         ));
 
         self::assertInstanceOf(Err::class, $result);
+
+        /** @var \Printgraph\PhpSdk\Client\Response\ErrorResponse $error */
+        $error = $result->unwrapErr();
+        self::assertInstanceOf(\Printgraph\PhpSdk\Client\Response\ErrorResponse::class, $error);
+        self::assertEquals(500, $error->getStatusCode());
+        self::assertTrue($error->isServerError());
+        self::assertFalse($error->isClientError());
     }
 }


### PR DESCRIPTION
## Summary
- Result型にSuccessResponseとErrorResponseのValue Object型を導入
- `Result<ResponseInterface, ResponseInterface>`から明確な型定義に変更
- PHPStanアノテーションで型安全性を強化
- 型レベルでエラーと成功レスポンスが区別可能に

## 主な変更点
- `src/Client/Response/SuccessResponse.php` - 成功レスポンス専用Value Object
- `src/Client/Response/ErrorResponse.php` - エラーレスポンス専用Value Object  
- インターフェースとクラスのPHPStanアノテーション追加
- テストコードを新しい型定義に対応

## Test plan
- [x] PHPStan Level 9での静的解析 - パス
- [x] PHPUnitテスト - パス 
- [x] PHP CS-Fixerコードスタイルチェック - パス

🤖 Generated with [Claude Code](https://claude.ai/code)