### PR TITLE
fix: エラーハンドリングの改善

### DIFF
--- a/src/Client/Client.php
+++ b/src/Client/Client.php
@@ -18,17 +18,25 @@ final class Client implements ClientInterface
     /**
      * HTTPリクエストを実行し、型安全なResult型で結果を返す
      *
-     * @throws GuzzleException
+     * すべてのGuzzleExceptionを捕捉し、例外を発生させずにErr型で返す
+     * - HTTPエラー（4xx/5xx）: ErrorResponse::fromResponse()で処理
+     * - 接続エラー: ErrorResponse::fromException()で処理
+     *
      * @return Result<Response\SuccessResponse, Response\ErrorResponse>
      * @phpstan-return Result<Response\SuccessResponse, Response\ErrorResponse>
      */
     public function request(string $method, string $path, array $options = []): Result
     {
-        $response = $this->httpClient->request($method, $path, $options);
-        if ($response->getStatusCode() >= 400) {
-            return new Err(new Response\ErrorResponse($response));
-        }
+        try {
+            $response = $this->httpClient->request($method, $path, $options);
 
-        return new Ok(new Response\SuccessResponse($response));
+            if ($response->getStatusCode() >= 400) {
+                return new Err(Response\ErrorResponse::fromResponse($response));
+            }
+
+            return new Ok(new Response\SuccessResponse($response));
+        } catch (GuzzleException $exception) {
+            return new Err(Response\ErrorResponse::fromException($exception));
+        }
     }
 }

--- a/src/Client/Response/ErrorResponse.php
+++ b/src/Client/Response/ErrorResponse.php
@@ -4,32 +4,88 @@ declare(strict_types=1);
 
 namespace Printgraph\PhpSdk\Client\Response;
 
+use GuzzleHttp\Exception\GuzzleException;
 use Psr\Http\Message\ResponseInterface;
 
 /**
  * エラーレスポンスを表す値オブジェクト
  *
+ * HTTPエラーレスポンス（4xx/5xx）とGuzzleException（接続エラーなど）の両方に対応
+ *
  * @phpstan-immutable
  */
 final class ErrorResponse
 {
-    public function __construct(
-        private readonly ResponseInterface $response,
-    ) {}
+    private ?string $cachedErrorMessage = null;
 
-    public function getResponse(): ResponseInterface
+    public function __construct(
+        private readonly ?ResponseInterface $response = null,
+        private readonly ?GuzzleException $exception = null,
+    ) {
+        if ($this->response === null && $this->exception === null) {
+            throw new \InvalidArgumentException('Either response or exception must be provided');
+        }
+    }
+
+    /**
+     * HTTPレスポンスから生成
+     */
+    public static function fromResponse(ResponseInterface $response): self
+    {
+        return new self(response: $response);
+    }
+
+    /**
+     * Guzzle例外から生成
+     */
+    public static function fromException(GuzzleException $exception): self
+    {
+        // RequestExceptionがレスポンスを持つ場合は、レスポンスも保存
+        if ($exception instanceof \GuzzleHttp\Exception\RequestException
+            && method_exists($exception, 'hasResponse')
+            && $exception->hasResponse()
+            && method_exists($exception, 'getResponse')) {
+            return new self(
+                response: $exception->getResponse(),
+                exception: $exception
+            );
+        }
+
+        return new self(exception: $exception);
+    }
+
+    public function getResponse(): ?ResponseInterface
     {
         return $this->response;
     }
 
+    public function getException(): ?GuzzleException
+    {
+        return $this->exception;
+    }
+
     public function getStatusCode(): int
     {
-        return $this->response->getStatusCode();
+        return $this->response?->getStatusCode() ?? 0;
     }
 
     public function getErrorMessage(): string
     {
-        return $this->response->getBody()->getContents();
+        if ($this->cachedErrorMessage !== null) {
+            return $this->cachedErrorMessage;
+        }
+
+        if ($this->response !== null) {
+            $body = $this->response->getBody();
+            if ($body->isSeekable()) {
+                $body->rewind();
+            }
+            $this->cachedErrorMessage = $body->getContents();
+            return $this->cachedErrorMessage;
+        }
+
+        $this->cachedErrorMessage = $this->exception?->getMessage() ?? 'Unknown error';
+        return $this->cachedErrorMessage;
     }
 
     public function isClientError(): bool
@@ -45,10 +101,31 @@ final class ErrorResponse
     }
 
     /**
+     * HTTP接続エラー（タイムアウト、DNS解決失敗など）の場合true
+     */
+    public function isConnectionError(): bool
+    {
+        // HTTPレスポンスがある場合は接続エラーではない
+        if ($this->response !== null) {
+            return false;
+        }
+
+        // RequestExceptionでレスポンスを持つ場合も接続エラーではない
+        if ($this->exception instanceof \GuzzleHttp\Exception\RequestException
+            && method_exists($this->exception, 'hasResponse')
+            && $this->exception->hasResponse()) {
+            return false;
+        }
+
+        // その他の例外は接続エラーとして扱う
+        return $this->exception !== null;
+    }
+
+    /**
      * @return array<string, string[]>
      */
     public function getHeaders(): array
     {
-        return $this->response->getHeaders();
+        return $this->response?->getHeaders() ?? [];
     }
 }

--- a/tests/Client/ClientTest.php
+++ b/tests/Client/ClientTest.php
@@ -5,6 +5,9 @@ declare(strict_types=1);
 namespace Printgraph\PhpSdk\Tests\Client;
 
 use GuzzleHttp\ClientInterface as HttpClientInterface;
+use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\TestCase;
 use Printgraph\PhpSdk\Client\Client;
@@ -49,5 +52,63 @@ final class ClientTest extends TestCase
         self::assertEquals(400, $error->getStatusCode());
         self::assertTrue($error->isClientError());
         self::assertFalse($error->isServerError());
+        self::assertFalse($error->isConnectionError());
+        self::assertNotNull($error->getResponse());
+    }
+
+    public function testRequestConnectionError(): void
+    {
+        $httpClientMock = $this->createMock(HttpClientInterface::class);
+        $request = new Request('GET', '/test');
+        $exception = new ConnectException('Connection timeout', $request);
+
+        $httpClientMock->expects($this->once())
+            ->method('request')
+            ->with('GET', '/test', [])
+            ->willThrowException($exception);
+
+        $client = new Client($httpClientMock);
+        $result = $client->request('GET', '/test');
+        self::assertInstanceOf(Err::class, $result);
+
+        /** @var \Printgraph\PhpSdk\Client\Response\ErrorResponse $error */
+        $error = $result->unwrapErr();
+        self::assertInstanceOf(\Printgraph\PhpSdk\Client\Response\ErrorResponse::class, $error);
+        self::assertTrue($error->isConnectionError());
+        self::assertFalse($error->isClientError());
+        self::assertFalse($error->isServerError());
+        self::assertEquals(0, $error->getStatusCode());
+        self::assertEquals('Connection timeout', $error->getErrorMessage());
+        self::assertNull($error->getResponse());
+        self::assertSame($exception, $error->getException());
+    }
+
+    public function testRequestExceptionWithResponse(): void
+    {
+        $httpClientMock = $this->createMock(HttpClientInterface::class);
+        $request = new Request('GET', '/test');
+        $response = new Response(500, [], 'Internal Server Error');
+        $exception = new RequestException('Server error', $request, $response);
+
+        $httpClientMock->expects($this->once())
+            ->method('request')
+            ->with('GET', '/test', [])
+            ->willThrowException($exception);
+
+        $client = new Client($httpClientMock);
+        $result = $client->request('GET', '/test');
+        self::assertInstanceOf(Err::class, $result);
+
+        /** @var \Printgraph\PhpSdk\Client\Response\ErrorResponse $error */
+        $error = $result->unwrapErr();
+        self::assertInstanceOf(\Printgraph\PhpSdk\Client\Response\ErrorResponse::class, $error);
+
+        // 修正：レスポンスがあるので接続エラーではない
+        self::assertFalse($error->isConnectionError());
+        self::assertTrue($error->isServerError());
+        self::assertEquals(500, $error->getStatusCode());
+        self::assertEquals('Internal Server Error', $error->getErrorMessage());
+        self::assertNotNull($error->getResponse());
+        self::assertSame($exception, $error->getException());
     }
 }


### PR DESCRIPTION
## Summary
- getErrorMessage()メソッドのストリーム安全性を確保（キャッシュ機能追加）
- isConnectionError()の論理修正（RequestExceptionがレスポンスを持つ場合は接続エラーではない）  
- fromException()メソッドの改善（RequestExceptionのレスポンス保存対応）
- テストケースの論理修正

## Test plan
- [x] PHPUnit: 6テスト、41アサーション全て成功
- [x] PHPStan: レベル9でエラーなし
- [x] PHP CS-Fixer: コードスタイル適合

🤖 Generated with [Claude Code](https://claude.ai/code)