### PR TITLE
fix: PDF生成APIのエンドポイントをv1/pdf/generateに修正

### DIFF
--- a/src/Api/Pdf/Generator/Generator.php
+++ b/src/Api/Pdf/Generator/Generator.php
@@ -16,7 +16,7 @@ final class Generator implements GeneratorInterface
      */
     public function generate(GenerateRequest $generateRequest): Result
     {
-        return $this->client->request('POST', 'pdf/generate', [
+        return $this->client->request('POST', 'v1/pdf/generate', [
             'json' => [
                 'templateKey' => $generateRequest->templateKey,
                 'params' => $generateRequest->params,

--- a/tests/Api/Pdf/Generator/GeneratorTest.php
+++ b/tests/Api/Pdf/Generator/GeneratorTest.php
@@ -20,7 +20,7 @@ final class GeneratorTest extends TestCase
         $mockClient
             ->expects($this->once())
             ->method('request')
-            ->with('POST', 'pdf/generate', [
+            ->with('POST', 'v1/pdf/generate', [
                 'json' => [
                     'templateKey' => 'template',
                     'params' => ['param1' => 'value1', 'param2' => 'value2'],
@@ -52,7 +52,7 @@ final class GeneratorTest extends TestCase
         $mockClient
             ->expects($this->once())
             ->method('request')
-            ->with('POST', 'pdf/generate', [
+            ->with('POST', 'v1/pdf/generate', [
                 'json' => [
                     'templateKey' => 'template',
                     'params' => ['param1' => 'value1', 'param2' => 'value2'],


### PR DESCRIPTION
GeneratorクラスとGeneratorTestクラスで使用していたエンドポイント
URLを「pdf/generate」から正しい「v1/pdf/generate」に修正しました。