### PR TITLE
fix: templateKey を templateId に書き換える

### DIFF
--- a/src/Api/Pdf/Generator/GenerateRequest.php
+++ b/src/Api/Pdf/Generator/GenerateRequest.php
@@ -10,7 +10,7 @@ final class GenerateRequest
      * @param mixed[] $params
      */
     public function __construct(
-        public readonly string $templateKey,
+        public readonly string $templateId,
         public readonly array  $params,
     ) {}
 }

--- a/src/Api/Pdf/Generator/Generator.php
+++ b/src/Api/Pdf/Generator/Generator.php
@@ -18,7 +18,7 @@ final class Generator implements GeneratorInterface
     {
         return $this->client->request('POST', 'v1/pdf/generate', [
             'json' => [
-                'templateKey' => $generateRequest->templateKey,
+                'templateId' => $generateRequest->templateId,
                 'params' => $generateRequest->params,
             ],
             'headers' => [

--- a/tests/Api/Pdf/Generator/GeneratorTest.php
+++ b/tests/Api/Pdf/Generator/GeneratorTest.php
@@ -22,7 +22,7 @@ final class GeneratorTest extends TestCase
             ->method('request')
             ->with('POST', 'v1/pdf/generate', [
                 'json' => [
-                    'templateKey' => 'template',
+                    'templateId' => 'template',
                     'params' => ['param1' => 'value1', 'param2' => 'value2'],
                 ],
                 'headers' => [
@@ -54,7 +54,7 @@ final class GeneratorTest extends TestCase
             ->method('request')
             ->with('POST', 'v1/pdf/generate', [
                 'json' => [
-                    'templateKey' => 'template',
+                    'templateId' => 'template',
                     'params' => ['param1' => 'value1', 'param2' => 'value2'],
                 ],
                 'headers' => [


### PR DESCRIPTION
## Summary

- API が templateId を要求するようになっていたため、SDK 全体でも templateKey から templateId へ名称を統一しました

## 主な変更点

- 全体的に確認を行い、templateKey となっている箇所を templateId に書き換えました

## Test Plan

composer tests を実行しました
- [x] php-cs-fixer --dry-run でスタイル差分がないことを確認しました。
- [x] phpstan analyse を実行し、エラーがないことを確認しました。
- [x] phpunit を実行し、全テストがパスすることを確認しました。`OK (6 tests, 41 assertions)`