### PR TITLE
fix: paramsが空の場合にstdClassを送信するように修正

### DIFF
--- a/src/Api/Pdf/Generator/Generator.php
+++ b/src/Api/Pdf/Generator/Generator.php
@@ -34,7 +34,7 @@ final class Generator implements GeneratorInterface
         return $this->client->request('POST', 'v1/pdf/generate', [
             'json' => [
                 'templateId' => $generateRequest->templateId,
-                'params' => $generateRequest->params,
+                'params' => empty($generateRequest->params) ? new \stdClass() : $generateRequest->params,
                 'format' => $generateRequest->format,
             ],
             'headers' => [


### PR DESCRIPTION
## Summary
- PDF生成API呼び出し時に、`params`が空の場合に空のJSONオブジェクト(`{}`)を送信するように修正

## 問題
- `generateRequest->params`が空の配列の場合、JSONエンコード時に`[]`として送信されていた
- APIは空のパラメータをオブジェクト形式(`{}`)で期待しているため、配列形式だとエラーが発生する可能性がある

## 変更内容
- `empty($generateRequest->params)`の場合、`new \stdClass()`を使用して明示的に空のオブジェクトを送信
- それ以外の場合は従来通り`$generateRequest->params`をそのまま送信

## 影響範囲
- `Generator::generate()` メソッドのみ
- 既存の動作に影響なし（パラメータがある場合の動作は変更なし）

## Test plan
- [x] パラメータが空の場合のPDF生成が正常に動作することを確認
- [x] パラメータがある場合の既存の動作に影響がないことを確認
- [x] PHPStanとCS-Fixerが通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)